### PR TITLE
Update jQuery-FontSpy.js

### DIFF
--- a/jQuery-FontSpy.js
+++ b/jQuery-FontSpy.js
@@ -12,7 +12,7 @@
 
     function FontSpy ( element, conf ) {
         var $element = $(element),
-            fontFamily = $element.css("font-family");
+            fontFamily = $element.css("font-family").replace(/"/g, '').replace(/'/g, '');
         var defaults = {
             font: (fontFamily.search(',') > -1) ? fontFamily.match(/^(\w+),/)[1] : fontFamily,
             onLoad: '',


### PR DESCRIPTION
This allows custom fonts that are enclosed in single or upper quotes, with fallbacks, to not cause errors.