### PR TITLE
Update jQuery-FontSpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,48 @@
 
 ### Style your @font-face elements while they load or upon catastrophic failure.
 
-This works by checking the change in width of a string. Comic-Sans is used as the font to compare against as it is the most "unique" default font. Using a very large font-size, we are able to determine even the slightest change. When the width of the string changes, we know that the custom font-face file has been loaded and applied.
+jQuery-FontSpy.js works by checking the change in width of a string. Courier New is used as the font to compare against as it is one of the most widely distrubuted default fonts. Using a very large font-size, we are able to determine even the slightest change. When the width of the string changes, we know that the custom font-face file has been loaded and applied.
 
-Apply it to your project
+## Usage:
 
-	.bannerTextChecked {
-    		font-family: "Lobster";
-    		/* don't specify fallback font here, do this in onFail class */
-    }
+```javascript
+fontSpy('My Icons', {
+  glyphs: '\ue81a\ue82d\ue823',
+  success: function() {
+    //alert("My Icons loaded successfully");
+  },
+  failure: function() {
+    //alert("My Icons failed to load");
+  }
+});
+```
 
-	$(document).ready(function() {
+The first argument passed to fontSpy is the name of the font-family. This is used to style the test string when checking width changes.
 
-		$('.bannerTextChecked').fontSpy({
-			onLoad: 'hideMe',
-			onFail: 'fontFail anotherClass'
-		});
+The second argument is for options that can be passed to jQuery-FontSpy.
 
-	});
+If a custom font is loaded, a class with the font name is added to the html element.
+If a custom font fails to load, a class with the font name prefixed with `no-` is add to the HTML element.
 
-Remove that FOUC!
-
-	.hideMe {
-		visibility: hidden !important;
-	}
-
-	.fontFail {
-		visibility: visible !important;
-		/* fall back font */
-		/* necessary styling so fallback font doesn't break your layout */
-	}
+Font names are converted to lowercase and spaces are removed when converted to class names to be used on the HTML element.
+For example, the font name, `My Icons` will render as `myicons` when used an HTML class.
 
 
+## Options
 
+**glyphs:** If your font is mapped to PUA characters, you can pass a few of the glyphs contained in the custom font. We measure these characters to make sure the font has loaded successfully.
 
+**success:** If the font specified as in the first arguement passed to fontSpy loads, you can excute custom JavaScript here.
 
+**failure:** If the font specified as in the first arguement passed to fontSpy fails to load, you can excute custom JavaScript here.
 
+## Browser Support
+
+fontcheck has been tested and works in the following environments.
+
+* Chrome 40
+* Firefox 35
+* Safari 7.1
+* Internet Explorer 8, 9, 10, 11
+* Android 4.4.4 Stock Browser
+* iOS Safari 8.1

--- a/index.htm
+++ b/index.htm
@@ -22,48 +22,32 @@
 
 
 	<hr/>
-	<h1>NO FLASH OF UNSTYLED CONTENT</h1>
-	<hr/>
-	<p>
-		<span class="bannerTextChecked">jQuery-FontSpy.js</span>
-	</p>
-	<hr/>
-	<h1>FLASH OF UNSTYLED CONTENT</h1>
-	<hr/>
-	<p>
-		<span class="bannerText">jQuery-FontSpy.js</span>
-	</p>
-	<hr/>
-	<h1>BROKEN FONT LINK + RESIZE SMALL + COLOR + DIFFERENT FONT</h1>
-	<hr/>
-	<p>
-		<span class="bannerTextBrokenOne">jQuery-FontSpy.js</span>
-	</p>
-	<hr/>
-	<h1>BROKEN FONT LINK + RESIZE LARGE</h1>
-	<hr/>
-	<p>
-		<span class="bannerTextBrokenTwo">jQuery-FontSpy.js</span>
-	</p>
+	<main id="main">
+		<div>Lobster font <span id="lobster-result"></span>.</div>
+		<div>BROKEN font <span id="broken-result"></span>.</div>
+	</main>
 
 
 	<script>
 
 		$(document).ready(function() {
 
-			$('.bannerTextChecked').fontSpy({
-				onLoad: 'hideMe',
-				onFail: 'fontFail'
+			fontSpy('Lobster', {
+			  success: function() {
+			    $('#lobster-result').html("loaded successfully");
+			  },
+			  failure: function() {
+			   $('#lobster-result').html("failed to load");
+			  }
 			});
 
-			$('.bannerTextBrokenOne').fontSpy({
-				onLoad: 'hideMe',
-				onFail: 'fontFail makeSmall'
-			});
-
-			$('.bannerTextBrokenTwo').fontSpy({
-				onLoad: 'hideMe',
-				onFail: 'fontFail makeBig'
+			fontSpy('BROKEN', {
+			  success: function() {
+			    $('#broken-result').html("loaded successfully");
+			  },
+			  failure: function() {
+			   $('#broken-result').html("failed to load");
+			  }
 			});
 
 		});

--- a/jQuery-FontSpy.js
+++ b/jQuery-FontSpy.js
@@ -1,76 +1,89 @@
-/* jQuery-FontSpy.js v2.0.0
+/* jQuery-FontSpy.js v3.0.0
  * https://github.com/patrickmarabeas/jQuery-FontSpy.js
  *
  * Copyright 2013, Patrick Marabeas http://pulse-dev.com
  * Released under the MIT license
  * http://opensource.org/licenses/mit-license.php
  *
- * Date: 10/12/2013
+ * Date: 02/11/2015
  */
 
-(function($) {
+(function( w, $ ) {
 
-    function FontSpy ( element, conf ) {
-        var $element = $(element),
-            fontFamily = $element.css("font-family").replace(/"/g, '').replace(/'/g, '');
-        var defaults = {
-            font: (fontFamily.search(',') > -1) ? fontFamily.match(/^(\w+),/)[1] : fontFamily,
-            onLoad: '',
-            onFail: '',
-            testFont: 'Comic Sans MS',
-            testString: 'QW@HhsXJ',
-            delay: 50,
-            timeOut: 2500,
-            callback: $.noop
-        };
-        var config = $.extend( defaults, conf );
-        var $tester = $('<span>' + config.testString + '</span>')
-            .css('position', 'absolute')
-            .css('top', '-9999px')
-            .css('left', '-9999px')
-            .css('visibility', 'hidden')
-            .css('fontFamily', config.testFont)
-            .css('fontSize', '250px');
-        $('body').append($tester);
-        var fallbackFontWidth = $tester.outerWidth();
-        $tester.css('fontFamily', config.font + ',' + config.testFont);
+  fontSpy = function  ( fontName, conf ) {
+    var $html = $('html'),
+        $body = $('body'),
+        fontFamilyName = fontName;
 
-        function checkFont() {
-            var loadedFontWidth = $tester.outerWidth();
-            if (fallbackFontWidth !== loadedFontWidth){
-                success();
-            } else if(config.timeOut < 0) {
-                failure();
-            } else {
-                retry();
-            }
+        // Throw error if fontName is not a string or not is left as an empty string
+        if (typeof fontFamilyName !== 'string' || fontFamilyName === '') {
+          throw 'A valid fontName is required. fontName must be a string and must not be an empty string.';
         }
-        function failure () {
-            $element.removeClass(config.onLoad);
-            $element.addClass(config.onFail);
-            config.callback(new Error('FontSpy timeout'));
-            $tester.remove();
-        }
-        function success () {
-            config.callback();
-            $element.removeClass(config.onLoad);
-            $tester.remove();
-        }
-        function retry () {
-            $element.addClass(config.onLoad);
-            setTimeout(checkFont, config.delay);
-            config.timeOut = config.timeOut - config.delay;
-        }
-        checkFont();
-    }
 
-    $.fn.fontSpy = function(config) {
-        return this.each(function() {
-            if (undefined == $(this).data('fontSpy')) {
-                var plugin = new FontSpy(this, config);
-                $(this).data('fontSpy', plugin);
-            }
-        });
+    var defaults = {
+        font: fontFamilyName,
+        fontClass: fontFamilyName.toLowerCase().replace( /\s/g, '' ),
+        success: function() {},
+        failure: function() {},
+        testFont: 'Courier New',
+        testString: 'QW@HhsXJ',
+        glyphs: '',
+        delay: 50,
+        timeOut: 1000,
+        callback: $.noop
     };
 
-})(jQuery);
+    var config = $.extend( defaults, conf );
+
+    var $tester = $('<span>' + config.testString+config.glyphs + '</span>')
+        .css('position', 'absolute')
+        .css('top', '-9999px')
+        .css('left', '-9999px')
+        .css('visibility', 'hidden')
+        .css('fontFamily', config.testFont)
+        .css('fontSize', '250px');
+
+    $body.append($tester);
+
+    var fallbackFontWidth = $tester.outerWidth();
+
+    $tester.css('fontFamily', config.font + ',' + config.testFont);
+
+    var failure = function () {
+      $html.addClass("no-"+config.fontClass);
+      if( config && config.failure ) {
+        config.failure();
+      }
+      config.callback(new Error('FontSpy timeout'));
+      $tester.remove();
+    };
+
+    var success = function () {
+      config.callback();
+      $html.addClass(config.fontClass);
+      if( config && config.success ) {
+        config.success();
+      }
+      $tester.remove();
+    };
+
+    var retry = function () {
+      setTimeout(checkFont, config.delay);
+      config.timeOut = config.timeOut - config.delay;
+    };
+
+    var checkFont = function () {
+      var loadedFontWidth = $tester.outerWidth();
+
+      if (fallbackFontWidth !== loadedFontWidth){
+        success();
+      } else if(config.timeOut < 0) {
+        failure();
+      } else {
+        retry();
+      }
+    }
+
+    checkFont();
+    }
+  })( this, jQuery );

--- a/styles/main.css
+++ b/styles/main.css
@@ -38,6 +38,10 @@ html, body {
 	color: #f0efee;
 }
 
+#main {
+	padding: 20px;
+}
+
 h1 {
 	font-size: 12px;
 	font-weight: normal;
@@ -48,45 +52,18 @@ p {
 }
 
 
-
-.bannerText {
-	font-family: "Lobster";
-	font-size: 60px;
+.lobster #lobster-result {
+	color: green;
 }
 
-.bannerTextChecked {
-	font-family: "Lobster";
-	font-size: 60px;
+.no-lobster #lobster-result {
+	color: red;
 }
 
-.bannerTextBrokenOne {
-	font-family: "BROKEN";
-	font-size: 60px;
+.broken #broken-result {
+	color: green;
 }
 
-
-.bannerTextBrokenTwo {
-	font-family: "BROKEN";
-	font-size: 60px;
-}
-
-
-
-
-.hideMe {
-	visibility: hidden !important;
-}
-
-.fontFail {
-	visibility: visible !important;
-}
-
-.makeSmall {
-	font-size: 20px !important;
-	color: green !important;
-	font-family: verdana !important;
-}
-
-.makeBig {
-	font-size: 80px !important;
+.no-broken #broken-result {
+	color: red;
 }


### PR DESCRIPTION
Updated jQuery-FontSpy to align with some of the features from [a-font-garde](https://github.com/filamentgroup/a-font-garde)

**Changes**
* Ability to pass a font family name to fontSpy rather than pull first font family name in a font stack from DOM element.
* Ability to pass in glyphs to append to testString. (Nice for fonts mapped to PUA).
* Ability to execute JavaScript if a particular font successfully loads.
* Ability to execute JavaScript if a particular font fails to loads.
* Lowered default timeout to 1000ms.
* Updated index.htm to better display results from updated fontSpy function.
* Updated README with doc on new features.
* Updated default font to Courier New. This resolved false positives when testing on Android.